### PR TITLE
Added support for an object-type collection

### DIFF
--- a/mingo.js
+++ b/mingo.js
@@ -279,7 +279,7 @@
         _.extend(this._operators, {"$project": this._projection});
       }
 
-      if (!_.isArray(this._collection)) {
+      if (!_.isArray(this._collection) && !_.isObject(this._collection)) {
         throw new Error("Input collection is not of a valid type.");
       }
 


### PR DESCRIPTION
As mingo uses undescore and underscore's methods work on collections this allows the collection to be an object.