### PR TITLE
Prevent date properties from being incorrectly cloned when specified as a projection

### DIFF
--- a/mingo.js
+++ b/mingo.js
@@ -779,7 +779,7 @@
           }
 
           if (newValue !== undefined) {
-            cloneObj[key] = _.isObject(newValue) ? _.clone(newValue) : newValue;
+            cloneObj[key] = _.isObject(newValue) && !(newValue instanceof Date) ? _.clone(newValue) : newValue;
           }
         });
         // if projection included $slice operator


### PR DESCRIPTION
With a document like:

`.insert({ _id: 'a', date: new Date() })`

and a find like:

`.find({}, { fields: { date: 1 } })`

Document is returned like:

`{ date: {}, _id: 'a' }`

This fixes the problem