### PR TITLE
Prevent sorting by identical dates from duplicating documents

### DIFF
--- a/mingo.js
+++ b/mingo.js
@@ -866,13 +866,11 @@
             indexes.push(value);
             return value;
           });
-          indexes = indexes.map(function (i) {
-            if (i && i instanceof Date) {
-              i = i.toString();
-            }
+          var groupedIndexes = groupBy(indexes, function (i) {
             return i;
           });
-          indexes = _.sortBy(_.uniq(indexes), function (item) {
+          indexes = groupedIndexes.keys;
+          indexes = _.sortBy(indexes, function (item) {
             return item;
           });
           if (sortKeys[key] === -1) {

--- a/mingo.js
+++ b/mingo.js
@@ -866,6 +866,12 @@
             indexes.push(value);
             return value;
           });
+          indexes = indexes.map(function (i) {
+            if (i && i instanceof Date) {
+              i = i.toString();
+            }
+            return i;
+          });
           indexes = _.sortBy(_.uniq(indexes), function (item) {
             return item;
           });


### PR DESCRIPTION
With documents like:

```
.insert({ _id: 'a', date: new Date(2017, 01, 01) })
.insert({ _id: 'b', date: new Date(2017, 01, 01) })
.insert({ _id: 'c', date: new Date(2018, 01, 01) })
```

and a find like:

`.find({}, { sort: { date: 1 } })`

Documents are returned like:

```
{ _id: 'a', date: new Date(2017, 01, 01) }
{ _id: 'b', date: new Date(2017, 01, 01) }
{ _id: 'a', date: new Date(2017, 01, 01) }
{ _id: 'b', date: new Date(2017, 01, 01) }
{ _id: 'c', date: new Date(2018, 01, 01) }
```

This fixes the problem.

The issue is due to `_.uniq` not being able to unique date objects. This converts the date objects to strings so they can be uniqued and then sorted appropriately.