### PR TITLE
allow use of "$in" and "$nin" as aggregation comparison operators

### DIFF
--- a/mingo.js
+++ b/mingo.js
@@ -2224,7 +2224,7 @@
     }
   };
   // mixin comparison operators
-  ["$eq", "$ne", "$gt", "$gte", "$lt", "$lte"].forEach(function (op) {
+  ["$eq", "$ne", "$gt", "$gte", "$lt", "$lte", "$in", "$nin"].forEach(function (op) {
     comparisonOperators[op] = function (obj, expr) {
       var args = computeValue(obj, expr, null);
       return simpleOperators[op](args[0], args[1]);

--- a/test/aggregation.js
+++ b/test/aggregation.js
@@ -556,7 +556,7 @@ test("Set Operators", function (t) {
 });
 
 test("Boolean Operators", function (t) {
-  t.plan(3);
+  t.plan(5);
   var inventory = [
     {"_id": 1, "item": "abc1", description: "product 1", qty: 300},
     {"_id": 2, "item": "abc2", description: "product 2", qty: 200},
@@ -609,6 +609,36 @@ test("Boolean Operators", function (t) {
     {"_id": 4, "item": "VWZ1", "result": false},
     {"_id": 5, "item": "VWZ2", "result": true}
   ], result, "can apply $not aggregate operator");
+
+  result = Mingo.aggregate(inventory, [{
+    $project: {
+      item: 1,
+      result: {$in: ["$item", ['abc1', 'abc2']]}
+    }
+  }]);
+
+  t.deepEqual([
+    {"_id": 1, "item": "abc1", "result": true},
+    {"_id": 2, "item": "abc2", "result": true},
+    {"_id": 3, "item": "xyz1", "result": false},
+    {"_id": 4, "item": "VWZ1", "result": false},
+    {"_id": 5, "item": "VWZ2", "result": false}
+  ], result, "can apply $in aggregate operator");
+
+  result = Mingo.aggregate(inventory, [{
+    $project: {
+      item: 1,
+      result: {$nin: ["$item", ['abc1', 'abc2']]}
+    }
+  }]);
+
+  t.deepEqual([
+    {"_id": 1, "item": "abc1", "result": false},
+    {"_id": 2, "item": "abc2", "result": false},
+    {"_id": 3, "item": "xyz1", "result": true},
+    {"_id": 4, "item": "VWZ1", "result": true},
+    {"_id": 5, "item": "VWZ2", "result": true}
+  ], result, "can apply $nin aggregate operator");
 
   t.end();
 });


### PR DESCRIPTION
Allow use of [$in](https://docs.mongodb.com/manual/reference/operator/query/in/) and [$nin](https://docs.mongodb.com/manual/reference/operator/query/nin/) as aggregation comparison operators.

Example:

```js
const Mingo = require('mingo')

let collection = [{ one: 1 }]
let pipeline = [{
  $project: {
    result: {
      $in: ['$one', [1]]
    }
  }
}]

console.log(Mingo.aggregate(collection, pipeline))
```

Result:

Before: `[{ result: { $in: [1, [1]] } }]`. 
After: `[{ result: true }]`
