### PR TITLE
$lookup as reference

### DIFF
--- a/lib/operators/pipeline/lookup.js
+++ b/lib/operators/pipeline/lookup.js
@@ -41,7 +41,7 @@ export function $lookup (collection, expr) {
     let k = hashCode(obj[localField])
     let indexes = hash[k] || []
     let newObj = clone(obj)
-    newObj[asField] = map(indexes, (i) => clone(joinColl[i]))
+    newObj[asField] = map(indexes, (i) => joinColl[i])
     result.push(newObj)
   })
 


### PR DESCRIPTION
$lookups are safe. No need to clone.

As @kofrasa [said](https://github.com/kofrasa/mingo/issues/61#issuecomment-327409086):
> forgot to remove the clone. must fix