### PR TITLE
Work around iOS 9 Safari compatibility problem

### DIFF
--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -20,7 +20,15 @@ const OPERATORS = {
  * Returns the operators defined for the given operator classes
  */
 export function ops () {
-  return reduce(arguments, (acc, cls) => into(acc, keys(OPERATORS[cls])), [])
+  // Workaround for browser-compatibility bug: on iPhone 6S Safari (and
+  // probably some other platforms), `arguments` isn't detected as an array,
+  // but has a length field, so functions like `reduce` and up including the
+  // length field in their iteration. Copy to a real array.
+  const argsArray = [];
+  for (let i=0; i<arguments.length; i++)
+    argsArray.push(arguments[i]);
+  
+  return reduce(argsArray, (acc, cls) => into(acc, keys(OPERATORS[cls])), [])
 }
 
 /**

--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -24,7 +24,9 @@ export function ops () {
   // probably some other platforms), `arguments` isn't detected as an array,
   // but has a length field, so functions like `reduce` and up including the
   // length field in their iteration. Copy to a real array.
-  const argsArray = Array.prototype.slice.call(arguments);
+  const argsArray = [];
+  for (let arg of arguments)
+    argsArray.push(arg);
   
   return reduce(argsArray, (acc, cls) => into(acc, keys(OPERATORS[cls])), [])
 }

--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -24,9 +24,7 @@ export function ops () {
   // probably some other platforms), `arguments` isn't detected as an array,
   // but has a length field, so functions like `reduce` and up including the
   // length field in their iteration. Copy to a real array.
-  const argsArray = [];
-  for (let i=0; i<arguments.length; i++)
-    argsArray.push(arguments[i]);
+  const argsArray = Array.prototype.slice.call(arguments);
   
   return reduce(argsArray, (acc, cls) => into(acc, keys(OPERATORS[cls])), [])
 }


### PR DESCRIPTION
We're observing a crash on iOS Safari. Stepping through with a debugger points to what looks like a quirk in how it handles `arguments`.

`ops` in `lib/operators/index.js` currently looks like this:

```
/**
 * Returns the operators defined for the given operator classes
 */
export function ops () {
  return reduce(arguments, (acc, cls) => into(acc, keys(OPERATORS[cls])), [])
}
```

Where `reduce` is implemented in `lib/util.js`, and looks like this:

```
/**
 * Reduce any array-like object
 * @param collection
 * @param fn
 * @param accumulator
 * @returns {*}
 */
export function reduce (collection, fn, accumulator) {
  if (isArray(collection)) return collection.reduce(fn, accumulator)
  // array-like objects
  each(collection, (v, k) => accumulator = fn(accumulator, v, k, collection))
  return accumulator
}
```

It seems that `isArray` returns false on `arguments`, and then iterating over it with `each` (or with a `for...in` loop) includes the `length` key. (This part is a browser quirk; `arguments` is array-like and should act like an array, and on Chrome at least, it does.) The value under the `length` key gets used as an index into `OPERATORS`, resulting in undefined, which gets passed to `keys`, which crashes.

If I rewrite `ops` to copy from `arguments` into a real array, it works.