### PR TITLE
No-op change to test Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,4 @@ test: mingo.js
 
 
 .PHONY: clean test build coverage
+


### PR DESCRIPTION
In my other PR, unit tests are failing in Travis, even though they pass locally. As a control, this PR has no changes of consequence (it just adds a newline at the end of `Makefile`), to separate problems with the CI setup from problems with the PR itself.