### PR TITLE
Fixing typing for aggregator.run, make query optional.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ declare namespace mingo {
      * @param collection an array of objects to process
      * @param query the `Query` object to use as context
      */
-    run<P>(collection: Array<any>, query: Query): P[];
+    run<P>(collection: Array<any>, query?: Query): P[];
   }
 
   /**


### PR DESCRIPTION
The source code (https://github.com/kofrasa/mingo/blob/master/lib/aggregator.js#L36) and docs suggest that the query parameter should be optional. Fixing the typing definition to allow for an optional query parameter.