### PR TITLE
$map 'as' operand should default to `this`

### DIFF
--- a/src/operators/expression/array/map.ts
+++ b/src/operators/expression/array/map.ts
@@ -14,7 +14,7 @@ export function $map(obj: object, expr: any, options: Options): any {
   let inputExpr = computeValue(obj, expr.input, null, options)
   assert(isArray(inputExpr), `$map 'input' expression must resolve to an array`)
 
-  let asExpr = expr['as']
+  let asExpr = expr['as'] || 'this'
   let inExpr = expr['in']
 
   // HACK: add the "as" expression as a value on the object to take advantage of "resolve()"

--- a/test/expression/array_operators.js
+++ b/test/expression/array_operators.js
@@ -192,6 +192,33 @@ test('Array Operators: $map', function (t) {
   t.end()
 })
 
+test('Array Operators: $map without "as"', function (t) {
+  // $map
+  let result = mingo.aggregate([
+    {_id: 1, quizzes: [5, 6, 7]},
+    {_id: 2, quizzes: []},
+    {_id: 3, quizzes: [3, 8, 9]}
+  ], [
+    {
+      $project: {
+        adjustedGrades: {
+          $map: {
+            input: '$quizzes',
+            in: {$add: ['$$this', 2]}
+          }
+        }
+      }
+    }
+  ])
+
+  t.deepEqual([
+    {'_id': 1, 'adjustedGrades': [7, 8, 9]},
+    {'_id': 2, 'adjustedGrades': []},
+    {'_id': 3, 'adjustedGrades': [5, 10, 11]}
+  ], result, 'can apply $map operator')
+  t.end()
+})
+
 test('more $slice examples', function (t) {
   let data = [
     { "_id" : 1, "name" : "dave123", favorites: [ "chocolate", "cake", "butter", "apples" ] },


### PR DESCRIPTION
`$map` operator's `as` operand is officially optional and should default to `this`. Resolves #142.