### PR TITLE
fix $bucket default and boundaries mutation

### DIFF
--- a/src/operators/pipeline/bucket.ts
+++ b/src/operators/pipeline/bucket.ts
@@ -17,7 +17,7 @@ import { Lazy, Iterator } from '../../lazy'
  * @param {Options} opt Pipeline options
  */
 export function $bucket(collection: Iterator, expr: any, options: Options): Iterator {
-  let boundaries = expr.boundaries
+  let boundaries = [...expr.boundaries]
   let defaultKey = expr['default']
   let lower = boundaries[0] // inclusive
   let upper = boundaries[boundaries.length - 1] // exclusive
@@ -33,7 +33,7 @@ export function $bucket(collection: Iterator, expr: any, options: Options): Iter
 
   !isNil(defaultKey)
     && (getType(expr.default) === getType(lower))
-    && assert(lower > expr.default || upper < expr.default, "$bucket 'default' expression must be out of boundaries range")
+    && assert(expr.default >= upper || expr.default < lower, "$bucket 'default' expression must be out of boundaries range")
 
   let grouped = {}
   each(boundaries, (k) => grouped[k] = [])


### PR DESCRIPTION
$bucket docs say:

``` 	
Optional. A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.

If unspecified, each input document must resolve the groupBy expression to a value within one of the bucket ranges specified by boundaries or the operation throws an error.

The default value must be less than the lowest boundaries value, or greater than or equal to the highest boundaries value.

The default value can be of a different type than the entries in boundaries.
```

fix the assert there that won't allow `$bucket: { boundaries: [0, 10], default: 10 }` 
shallow copy the boundaries array since it uses mutation, closes #147