### PR TITLE
hash: Add option to set custom hash function

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -26,11 +26,17 @@ export interface CollationSpec {
 }
 
 /**
+ * Custom function to hash values to improve faster comparaisons
+ */
+export type HashFunction =  (v: any) => string | number
+
+/**
  * Generic options interface passed down to all operators
  */
 export interface Options {
   readonly idKey: string;
-  readonly collation?: CollationSpec
+  readonly collation?: CollationSpec;
+  readonly hashFunction?:HashFunction
 }
 
 /**

--- a/src/operators/_predicates.ts
+++ b/src/operators/_predicates.ts
@@ -107,7 +107,7 @@ export function $in(a: any, b: any, options?: Options): boolean {
   // queries for null should be able to find undefined fields
   if (isNil(a)) return b.some(isNull)
 
-  return intersection(ensureArray(a), b).length > 0
+  return intersection(ensureArray(a), b, options?.hashFunction).length > 0
 }
 
 /**
@@ -215,7 +215,7 @@ export function $all(a: any, b: any, options?: Options): boolean {
         matched = matched || $elemMatch(a, b[i].$elemMatch, options)
       } else {
         // order of arguments matter
-        return intersection(b, a).length === len
+        return intersection(b, a, options?.hashFunction).length === len
       }
     }
   }

--- a/src/operators/accumulator/addToSet.ts
+++ b/src/operators/accumulator/addToSet.ts
@@ -11,5 +11,5 @@ import { Options } from '../../core'
  * @returns {*}
  */
 export function $addToSet(collection: any[], expr: any, options: Options): any {
-  return unique($push(collection, expr, options))
+  return unique($push(collection, expr, options), options?.hashFunction)
 }

--- a/src/operators/expression/set/setEquals.ts
+++ b/src/operators/expression/set/setEquals.ts
@@ -12,7 +12,7 @@ import { computeValue, Options } from '../../../core'
  */
 export function $setEquals(obj: object, expr: any, options: Options): any {
   let args = computeValue(obj, expr, null, options)
-  let xs = unique(args[0])
-  let ys = unique(args[1])
-  return xs.length === ys.length && xs.length === intersection(xs, ys).length
+  let xs = unique(args[0], options?.hashFunction)
+  let ys = unique(args[1], options?.hashFunction)
+  return xs.length === ys.length && xs.length === intersection(xs, ys, options?.hashFunction).length
 }

--- a/src/operators/expression/set/setIntersection.ts
+++ b/src/operators/expression/set/setIntersection.ts
@@ -13,5 +13,5 @@ import { computeValue, Options } from '../../../core'
  */
 export function $setIntersection(obj: object, expr: any, options: Options): any {
   let args = computeValue(obj, expr, null, options)
-  return intersection(args[0], args[1])
+  return intersection(args[0], args[1], options?.hashFunction)
 }

--- a/src/operators/expression/set/setIsSubset.ts
+++ b/src/operators/expression/set/setIsSubset.ts
@@ -12,5 +12,5 @@ import { computeValue, Options } from '../../../core'
  */
 export function $setIsSubset(obj: object, expr: any, options: Options): any {
   let args = computeValue(obj, expr, null, options)
-  return intersection(args[0], args[1]).length === args[0].length
+  return intersection(args[0], args[1], options?.hashFunction).length === args[0].length
 }

--- a/src/operators/pipeline/bucketAuto.ts
+++ b/src/operators/pipeline/bucketAuto.ts
@@ -31,7 +31,7 @@ export function $bucketAuto(collection: Iterator, expr: any, options: Options): 
 
   return collection.transform(coll => {
     let approxBucketSize = Math.max(1, Math.round(coll.length / bucketCount))
-    let computeValueOptimized = memoize(computeValue)
+    let computeValueOptimized = memoize(computeValue, options?.hashFunction)
     let grouped = {}
     let remaining = []
 

--- a/src/operators/pipeline/group.ts
+++ b/src/operators/pipeline/group.ts
@@ -18,7 +18,7 @@ export function $group(collection: Iterator, expr: any, options: Options): Itera
   let id = expr[ID_KEY]
 
   return collection.transform(coll => {
-    let partitions = groupBy(coll, obj => computeValue(obj, id, null, options))
+    let partitions = groupBy(coll, obj => computeValue(obj, id, null, options), options?.hashFunction)
 
     // remove the group key
     expr = into({}, expr)

--- a/src/operators/pipeline/lookup.ts
+++ b/src/operators/pipeline/lookup.ts
@@ -28,13 +28,13 @@ export function $lookup(collection: Iterator, expr: any, options: Options): Iter
   let hash = {}
 
   each(joinColl, obj => {
-    let k = hashCode(resolve(obj, foreignField))
+    let k = hashCode(resolve(obj, foreignField), options?.hashFunction)
     hash[k] = hash[k] || []
     hash[k].push(obj)
   })
 
   return collection.map(obj => {
-    let k = hashCode(resolve(obj, localField))
+    let k = hashCode(resolve(obj, localField), options?.hashFunction)
     let newObj = into({}, obj)
     newObj[asField] = hash[k] || []
     return newObj

--- a/src/operators/pipeline/sort.ts
+++ b/src/operators/pipeline/sort.ts
@@ -39,7 +39,7 @@ export function $sort(collection: Iterator, sortKeys: object, options: Options):
     let modifiers = keys(sortKeys)
 
     each(modifiers.reverse(), key => {
-      let grouped = groupBy(coll, obj => resolve(obj, key))
+      let grouped = groupBy(coll, obj => resolve(obj, key), options?.hashFunction)
       let sortedIndex = {}
 
       let indexKeys = sortBy(grouped.keys, (k, i) => {

--- a/test/query_operators.js
+++ b/test/query_operators.js
@@ -572,3 +572,31 @@ test('null or missing fields', function (t) {
   }
   t.end()
 })
+
+
+test('hash function collision', function (t) {
+	let data = [{ "codes": ["KNE_OC42-midas"]	}, { "codes": ["KNE_OCS3-midas"] }];
+	let fixtures = [
+		{
+			query: { codes: { $in: ["KNE_OCS3-midas"] } },
+			result: [ { codes: [ 'KNE_OC42-midas' ] }, { codes: [ 'KNE_OCS3-midas' ] } ],
+			options: {},
+			message: 'should return both documents due to hash collision with default hash function'
+		},
+		{
+			query: { codes: { $in: ["KNE_OCS3-midas"] } },
+			result: [{ codes: [ 'KNE_OCS3-midas' ] } ],
+			options: {
+				hashFunction: (v) => JSON.stringify(v) // basic hash function, but has low performances
+			},
+			message: 'should return the good document due to no hash collision with custom hash function'
+		}
+	]
+	for (let i = 0; i < fixtures.length; i++) {
+		let line = fixtures[i]
+		let query = new mingo.Query(line.query, line.options)
+		let res = query.find(data).all()
+		t.deepEqual(res, line.result, line.message)
+	}
+	t.end()
+})


### PR DESCRIPTION
Hello,

While using mingo, I faced on hash collision that are blocking some usages.

Here a PR to allow users to give there own hash function if the prefer to.

I added a test with the collision values I got, I named it `hash function collision`.

@kofrasa Could you review it ? It is related to the issue #62 

Thanks in advance :smiley: 