### PR TITLE
Support for object type names with integer characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingo",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "MongoDB query language for in-memory objects",
   "main": "./lib/index.js",
   "module": "./lib/index.js",

--- a/src/util.ts
+++ b/src/util.ts
@@ -73,7 +73,7 @@ const JS_SIMPLE_TYPES = [JsType.NULL, JsType.UNDEFINED, JsType.BOOLEAN, JsType.N
 const OBJECT_PROTOTYPE = Object.getPrototypeOf({})
 const OBJECT_TO_STRING = Object.prototype.toString
 const OBJECT_TAG = '[object Object]'
-const OBJECT_TYPE_RE = /^\[object ([a-zA-Z]+)\]$/
+const OBJECT_TYPE_RE = /^\[object ([a-zA-Z0-9]+)\]$/
 
 export function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message)


### PR DESCRIPTION
This issues #158 and adds support for object types that has integers in it such as `Uint8Array`