### PR TITLE
fix(elem-match): handle $and/$or/$nor

### DIFF
--- a/test/query_operators.js
+++ b/test/query_operators.js
@@ -234,6 +234,66 @@ test('Query $elemMatch operator', function (t) {
   t.end()
 })
 
+test('Query $elemMatch operator with non-boolean operators', function (t) {
+  let products = [
+    { _id: 3, results: [ { product: "abc", score: 7 }, { product: "xyz", score: 8 } ] }
+  ]
+
+  let result = mingo.find(products, { results: { $elemMatch: {
+    $and: [
+      { product: "xyz" },
+      { score: 8 }
+    ]
+  } } }).all()[0]
+
+  t.deepEqual(
+    result,
+    { "_id" : 3, "results" : [ { "product" : "abc", "score" : 7 }, { "product" : "xyz", "score" : 8 } ] },
+    '$elemMatch with $and'
+  )
+
+  result = mingo.find(products, { results: { $elemMatch: {
+    $and: [
+      { product: "xyz" },
+      { score: 9 }
+    ]
+  } } }).all()[0]
+
+  t.deepEqual(
+    result,
+    undefined,
+    '$elemMatch with $and that does not match'
+  )
+
+  result = mingo.find(products, { results: { $elemMatch: {
+    $or: [
+      { product: "xyz" },
+      { score: 8 }
+    ]
+  } } }).all()[0]
+
+  t.deepEqual(
+    result,
+    { "_id" : 3, "results" : [ { "product" : "abc", "score" : 7 }, { "product" : "xyz", "score" : 8 } ] },
+    '$elemMatch with $or'
+  )
+
+  result = mingo.find(products, { results: { $elemMatch: {
+    $nor: [
+      { product: "abc" },
+      { score: 7 }
+    ]
+  } } }).all()[0]
+
+  t.deepEqual(
+    result,
+    { "_id" : 3, "results" : [ { "product" : "abc", "score" : 7 }, { "product" : "xyz", "score" : 8 } ] },
+    '$elemMatch with $nor'
+  )
+
+  t.end()
+})
+
 test('Evaluate $where last', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Fixes https://github.com/kofrasa/mingo/issues/163

### Overview:
The transformation [here](https://github.com/kofrasa/mingo/commit/8e9d869e51a2287bbd6d7fc9b65ac517ad2e5719#diff-ff3dbd87a61f50199234909a498a2d2e32f2c35437663976968d1a7c04dab8a2R218-R223) accounts for queries like the following that act on array elements that are not "full" objects:
```
$elemMatch: { $gte: 80, $lt: 85 }
```
but doesn't account for queries like:
```
$elemMatch: {
  $and: [
    { product: "xyz" },
    { score: 8 }
  ]
}
```
The changes in this PR allow `$elemMatch` to work with queries that use `$and`, `$or` or `$nor`

### Testing

I used Test Driven Development to create tests for `$and`, `$or` and `$nor` that fail with the code in the master branch. I then created a fix and ensured that all the exists tests still pass. I opted to put the new tests in a separate function as there are various scenarios that needed coverage and I think it would be a good idea to keep this from bloating the existing tests. 