### PR TITLE
Fix  unwind op incorrectly remove  0 value bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.2 / 2021-02-17
+
+* Fix `$unwind` incorrectly remove `0` value bug
+
 ## 4.1.1 / 2021-01-31
 
 * Fix `$elemMatch` to support top-level boolean operators `$and`,`$or`, and `$nor`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingo",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "MongoDB query language for in-memory objects",
   "main": "./lib/index.js",
   "module": "./lib/index.js",

--- a/src/util.ts
+++ b/src/util.ts
@@ -172,9 +172,9 @@ export function truthy(arg: AnyVal): boolean {
 export function isEmpty(x: AnyVal): boolean {
   return (
     isNil(x) ||
+    (isString(x) && !x) ||
     (x instanceof Array && x.length === 0) ||
-    (isObject(x) && Object.keys(x).length === 0) ||
-    !x
+    (isObject(x) && Object.keys(x).length === 0)
   );
 }
 // ensure a value is an array or wrapped within one

--- a/test/pipeline/unwind_operator.js
+++ b/test/pipeline/unwind_operator.js
@@ -66,5 +66,16 @@ test("$unwind pipeline operator", function (t) {
       { "_id" : 3, "item" : "IJK", "a" : { "sizes" : "M" } }
     ], '$unwind array nested within object')
 
+    result = mingo.aggregate([
+      { "_id" : 1, "number" : 0},
+      { "_id" : 2, "number" : 1}
+    ], [ { $unwind: "$number" } ] )
+
+    t.deepEqual(result, [
+      { "_id" : 1, "number" : 0},
+      { "_id" : 2, "number" : 1}
+    ], '$unwind has 0 value item')
+
+
   t.end()
 });

--- a/test/util_tests.js
+++ b/test/util_tests.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { isEqual, sortBy, isObject } from '../lib/util'
+import { isEqual, sortBy, isObject,isEmpty } from '../lib/util'
 
 test('Test isEqual', function (t) {
   let sample = [
@@ -74,5 +74,12 @@ test('Test isObject', (t) => {
     t.equal(isObject(arr[0]), arr[1], arr[2])
   })
 
+  t.end()
+})
+
+
+test('isEmpty util', function (t) {
+  let sample = ['0',0,null,{},'',[]]
+  t.deepEqual(sample.map(x=>isEmpty(x)),[false,false,true,true,true,true],"pass test")
   t.end()
 })


### PR DESCRIPTION
Fixes #166
when the field value is 0, the original Mingo unwind will treat the value as a false value. However, This is a different behavior compared to the real mongo shell