### PR TITLE
Fix $filter operator context + default

### DIFF
--- a/src/operators/expression/array/filter.ts
+++ b/src/operators/expression/array/filter.ts
@@ -20,7 +20,7 @@ export function $filter(
 
   assert(isArray(input), "$filter 'input' expression must resolve to an array");
 
-  const tempKey = "$" + expr.as;
+  const tempKey = "$" + (expr.as || "this");
   return input.filter((o: AnyVal) => {
     obj[tempKey] = o;
     return computeValue(obj, expr.cond, null, options) === true;

--- a/src/operators/expression/array/filter.ts
+++ b/src/operators/expression/array/filter.ts
@@ -20,10 +20,9 @@ export function $filter(
 
   assert(isArray(input), "$filter 'input' expression must resolve to an array");
 
+  const tempKey = "$" + expr.as;
   return input.filter((o: AnyVal) => {
-    // inject variable
-    const tempObj = {};
-    tempObj["$" + expr.as] = o;
-    return computeValue(tempObj, expr.cond, null, options) === true;
+    obj[tempKey] = o;
+    return computeValue(obj, expr.cond, null, options) === true;
   });
 }

--- a/test/expression/array_operators.ts
+++ b/test/expression/array_operators.ts
@@ -323,6 +323,109 @@ test('Array Operators: $map without "as"', (t) => {
   t.end();
 });
 
+test("Array Operators: $filter", (t) => {
+  // $filter
+  const result = aggregate(
+    [
+      { _id: 1, quizzes: [5, 6, 7] },
+      { _id: 2, quizzes: [] },
+      { _id: 3, quizzes: [3, 8, 9] },
+    ],
+    [
+      {
+        $project: {
+          passingGrades: {
+            $filter: {
+              input: "$quizzes",
+              as: "grade",
+              cond: { $gt: ["$$grade", 5] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, passingGrades: [6, 7] },
+      { _id: 2, passingGrades: [] },
+      { _id: 3, passingGrades: [8, 9] },
+    ],
+    result,
+    "can apply $filter operator"
+  );
+  t.end();
+});
+
+test('Array Operators: $filter without "as"', (t) => {
+  // $filter
+  const result = aggregate(
+    [
+      { _id: 1, quizzes: [5, 6, 7] },
+      { _id: 2, quizzes: [] },
+      { _id: 3, quizzes: [3, 8, 9] },
+    ],
+    [
+      {
+        $project: {
+          passingGrades: {
+            $filter: {
+              input: "$quizzes",
+              cond: { $gt: ["$$this", 5] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, passingGrades: [6, 7] },
+      { _id: 2, passingGrades: [] },
+      { _id: 3, passingGrades: [8, 9] },
+    ],
+    result,
+    "can apply $filter operator"
+  );
+  t.end();
+});
+
+test("Array Operators: $filter using object context", (t) => {
+  // $filter
+  const result = aggregate(
+    [
+      { _id: 1, quizzes: [5, 6, 7], minimum: 5 },
+      { _id: 2, quizzes: [], minimum: 5 },
+      { _id: 3, quizzes: [3, 8, 9], minimum: 5 },
+    ],
+    [
+      {
+        $project: {
+          passingGrades: {
+            $filter: {
+              input: "$quizzes",
+              cond: { $gt: ["$$this", 5] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, passingGrades: [6, 7] },
+      { _id: 2, passingGrades: [] },
+      { _id: 3, passingGrades: [8, 9] },
+    ],
+    result,
+    "can apply $filter operator"
+  );
+  t.end();
+});
+
 test("more $slice examples", (t) => {
   const data = [
     {

--- a/test/expression/array_operators.ts
+++ b/test/expression/array_operators.ts
@@ -323,6 +323,40 @@ test('Array Operators: $map without "as"', (t) => {
   t.end();
 });
 
+test("Array Operators: $map using object context", (t) => {
+  // $map
+  const result = aggregate(
+    [
+      { _id: 1, quizzes: [5, 6, 7], adjustment: 2 },
+      { _id: 2, quizzes: [], adjustment: 2 },
+      { _id: 3, quizzes: [3, 8, 9], adjustment: 2 },
+    ],
+    [
+      {
+        $project: {
+          adjustedGrades: {
+            $map: {
+              input: "$quizzes",
+              in: { $add: ["$$this", "$adjustment"] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, adjustedGrades: [7, 8, 9] },
+      { _id: 2, adjustedGrades: [] },
+      { _id: 3, adjustedGrades: [5, 10, 11] },
+    ],
+    result,
+    "can apply $map operator"
+  );
+  t.end();
+});
+
 test("Array Operators: $filter", (t) => {
   // $filter
   const result = aggregate(


### PR DESCRIPTION
This fixes #187 by using the object context passed into the operator when resolving the condition. This also adds the missing default value for "as", defaulting to "this" per the Mongo docs.

Tests have been added for $filter, matching closely the existing tests for $map, to test standard usage, as well as usage without "as" being set, and usage relying on the object context. I also added an additional test for $map to check the object context there too.