### PR TITLE
Regexes are not supported in $all queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "CHANGELOG.md"
   ],
   "devDependencies": {
-    "@types/lodash": "4.14.171",
-    "@types/node": "16.3.1",
-    "@types/tape": "4.13.1",
     "@typescript-eslint/eslint-plugin": "4.28.2",
     "@typescript-eslint/parser": "4.28.2",
+    "@types/node": "16.3.1",
+    "@types/tape": "4.13.1",
+    "@types/lodash": "4.14.172",
     "codecov": "3.8.3",
     "eslint": "7.30.0",
     "eslint-config-prettier": "8.3.0",
@@ -41,8 +41,8 @@
     "nyc": "15.1.0",
     "perf_hooks": "0.0.1",
     "prettier": "2.3.2",
+    "ts-node": "10.1.0",
     "tape": "5.2.2",
-    "ts-node": "^10.1.0",
     "typedoc": "0.21.5",
     "typescript": "4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "CHANGELOG.md"
   ],
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "4.28.2",
-    "@typescript-eslint/parser": "4.28.2",
+    "@types/lodash": "4.14.171",
     "@types/node": "16.3.1",
     "@types/tape": "4.13.1",
-    "@types/lodash": "4.14.171",
+    "@typescript-eslint/eslint-plugin": "4.28.2",
+    "@typescript-eslint/parser": "4.28.2",
     "codecov": "3.8.3",
     "eslint": "7.30.0",
     "eslint-config-prettier": "8.3.0",
@@ -41,8 +41,8 @@
     "nyc": "15.1.0",
     "perf_hooks": "0.0.1",
     "prettier": "2.3.2",
-    "ts-node": "10.1.0",
     "tape": "5.2.2",
+    "ts-node": "^10.1.0",
     "typedoc": "0.21.5",
     "typescript": "4.3.5"
   },

--- a/src/operators/_predicates.ts
+++ b/src/operators/_predicates.ts
@@ -226,19 +226,21 @@ export function $all(
   queries: RawArray,
   options?: Options
 ): boolean {
+  if (!isArray(values)) return false;
+  if (!isArray(queries)) return false;
+
+  if (queries.length === 0) return false;
+
   let matched = true;
-  if (isArray(values) && isArray(queries)) {
-    for (let i = 0, len = queries.length; i < len; i++) {
-      const query = queries[i];
-      if (isObject(query) && inArray(Object.keys(query), "$elemMatch")) {
-        matched = matched && $elemMatch(values, query["$elemMatch"], options);
-      } else if (query instanceof RegExp) {
-        matched =
-          matched &&
-          values.some((value) => testValueAgainstRegExp(value, query));
-      } else {
-        matched = matched && values.some((value) => query === value);
-      }
+  for (let i = 0, len = queries.length; i < len; i++) {
+    const query = queries[i];
+    if (isObject(query) && inArray(Object.keys(query), "$elemMatch")) {
+      matched = matched && $elemMatch(values, query["$elemMatch"], options);
+    } else if (query instanceof RegExp) {
+      matched =
+        matched && values.some((value) => testValueAgainstRegExp(value, query));
+    } else {
+      matched = matched && values.some((value) => query === value);
     }
   }
   return matched;

--- a/src/operators/_predicates.ts
+++ b/src/operators/_predicates.ts
@@ -217,23 +217,38 @@ export function $exists(a: AnyVal, b: AnyVal, options?: Options): boolean {
 /**
  * Matches arrays that contain all elements specified in the query.
  *
- * @param a
- * @param b
+ * @param values
+ * @param queries
  * @returns boolean
  */
-export function $all(a: RawArray, b: RawArray, options?: Options): boolean {
-  let matched = false;
-  if (isArray(a) && isArray(b)) {
-    for (let i = 0, len = b.length; i < len; i++) {
-      if (isObject(b[i]) && inArray(Object.keys(b[i]), "$elemMatch")) {
-        matched = matched || $elemMatch(a, b[i]["$elemMatch"], options);
+export function $all(
+  values: RawArray,
+  queries: RawArray,
+  options?: Options
+): boolean {
+  let matched = true;
+  if (isArray(values) && isArray(queries)) {
+    for (let i = 0, len = queries.length; i < len; i++) {
+      const query = queries[i];
+      if (isObject(query) && inArray(Object.keys(query), "$elemMatch")) {
+        matched = matched && $elemMatch(values, query["$elemMatch"], options);
+      } else if (query instanceof RegExp) {
+        matched =
+          matched &&
+          values.some((value) => testValueAgainstRegExp(value, query));
       } else {
-        // order of arguments matter
-        return intersection(b, a, options?.hashFunction).length === len;
+        matched = matched && values.some((value) => query === value);
       }
     }
   }
   return matched;
+}
+
+function testValueAgainstRegExp(value: unknown, regExp: RegExp) {
+  if (typeof value === "string") {
+    return regExp.test(value);
+  }
+  return false;
 }
 
 /**

--- a/src/operators/_predicates.ts
+++ b/src/operators/_predicates.ts
@@ -240,7 +240,7 @@ export function $all(
       matched =
         matched && values.some((value) => testValueAgainstRegExp(value, query));
     } else {
-      matched = matched && values.some((value) => query === value);
+      matched = matched && values.some((value) => isEqual(query, value));
     }
   }
   return matched;

--- a/test/query_operators.ts
+++ b/test/query_operators.ts
@@ -271,8 +271,8 @@ test("Match $all with strings, numbers and empty lists", (t) => {
 
   criteria["user.projects"].$all = [];
   t.ok(
-    find(data, criteria).count() === 3,
-    "match $all with an empty query returns all items"
+    find(data, criteria).count() === 0,
+    "match $all with an empty query returns no items"
   );
 });
 

--- a/test/query_operators.ts
+++ b/test/query_operators.ts
@@ -181,6 +181,101 @@ test("Match $all with $elemMatch on nested elements", (t) => {
   t.ok(result === 1, "can match using $all with $elemMatch on nested elements");
 });
 
+test("Match $all with regex", (t) => {
+  t.plan(3);
+
+  const data = [
+    {
+      user: {
+        username: "User1",
+        projects: ["foo", "bar"],
+      },
+    },
+    {
+      user: {
+        username: "User2",
+        projects: ["foo", "baz"],
+      },
+    },
+    {
+      user: {
+        username: "User3",
+        projects: ["fizz", "buzz"],
+      },
+    },
+    {
+      user: {
+        username: "User4",
+        projects: [],
+      },
+    },
+  ];
+  const criteria = {
+    "user.projects": {
+      $all: ["foo", /^ba/],
+    },
+  };
+  // It should return two user objects
+  const found = find(data, criteria);
+  const result = find(data, criteria).count();
+  t.ok(result === 2, "can match using $all with regex mixed with strings");
+  t.ok(
+    (found.next() as UserResult).user.username === "User1",
+    "returns user1 using $all with regex"
+  );
+  t.ok(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (found.next() as UserResult).user.username === "User2",
+    "returns user2 using $all with regex"
+  );
+});
+
+test("Match $all with strings, numbers and empty lists", (t) => {
+  t.plan(3);
+
+  const data = [
+    {
+      user: {
+        username: "User1",
+        projects: ["foo", 1],
+      },
+    },
+    {
+      user: {
+        username: "User2",
+        projects: ["foo", 2, "1"],
+      },
+    },
+    {
+      user: {
+        username: "User3",
+        projects: [],
+      },
+    },
+  ];
+  const criteria = {
+    "user.projects": {
+      $all: ["foo", 1],
+    },
+  };
+  // It should return two user objects
+  const found = find(data, criteria);
+  const result = find(data, criteria).count();
+  console.log(result);
+  t.ok(result === 1, "can match using $all with strings and numbers");
+  t.ok(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (found.next() as UserResult).user.username === "User1",
+    "returns user1 using $all with strings and numbers"
+  );
+
+  criteria["user.projects"].$all = [];
+  t.ok(
+    find(data, criteria).count() === 3,
+    "match $all with an empty query returns all items"
+  );
+});
+
 test("Projection $elemMatch operator", (t) => {
   const data = [
     {
@@ -1052,3 +1147,7 @@ test("hash function collision", (t) => {
   }
   t.end();
 });
+
+interface UserResult {
+  user: { username: string };
+}

--- a/test/query_operators.ts
+++ b/test/query_operators.ts
@@ -66,6 +66,10 @@ test("Comparison, Evaluation, and Element Operators", (t) => {
       "can check that all values exists in array with $all",
     ],
     [
+      { "languages.spoken": { $all: [/french/, /english/] } },
+      "can check that all values exists in array with $all using regex",
+    ],
+    [
       { date: { year: 2013, month: 9, day: 25 } },
       "can match field with object values",
     ],

--- a/test/query_operators.ts
+++ b/test/query_operators.ts
@@ -261,7 +261,6 @@ test("Match $all with strings, numbers and empty lists", (t) => {
   // It should return two user objects
   const found = find(data, criteria);
   const result = find(data, criteria).count();
-  console.log(result);
   t.ok(result === 1, "can match using $all with strings and numbers");
   t.ok(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -273,6 +272,39 @@ test("Match $all with strings, numbers and empty lists", (t) => {
   t.ok(
     find(data, criteria).count() === 0,
     "match $all with an empty query returns no items"
+  );
+});
+
+test("Match $all with deep objects", (t) => {
+  t.plan(2);
+
+  const data = [
+    {
+      user: {
+        username: "User1",
+        projects: [{ foo: { bar: 1 } }],
+      },
+    },
+    {
+      user: {
+        username: "User2",
+        projects: [{ foo: { bar: 2 } }],
+      },
+    },
+  ];
+  const criteria = {
+    "user.projects": {
+      $all: [{ foo: { bar: 1 } }],
+    },
+  };
+  // It should return two user objects
+  const found = find(data, criteria);
+  const result = find(data, criteria).count();
+  t.ok(result === 1, "can match using $all with deep object");
+  t.ok(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (found.next() as UserResult).user.username === "User1",
+    "returns user1 using $all with deep object"
   );
 });
 


### PR DESCRIPTION
This PR adds a new test to reproduce the issue

It appears that RegExp are not supported in [`$all` queries](https://docs.mongodb.com/manual/reference/operator/query/all/), [but they are in MongoDB](https://docs.mongodb.com/manual/reference/operator/query/regex/)