### PR TITLE
Fix frozen objects in $map/$filter

### DIFF
--- a/src/operators/expression/array/filter.ts
+++ b/src/operators/expression/array/filter.ts
@@ -17,12 +17,16 @@ export function $filter(
   options?: Options
 ): RawArray {
   const input = computeValue(obj, expr.input, null, options) as RawArray;
-
   assert(isArray(input), "$filter 'input' expression must resolve to an array");
 
   const tempKey = "$" + (expr.as || "this");
-  return input.filter((o: AnyVal) => {
-    obj[tempKey] = o;
-    return computeValue(obj, expr.cond, null, options) === true;
-  });
+  return input.filter(
+    (o: AnyVal) =>
+      computeValue(
+        Object.assign({}, obj, { [tempKey]: o }),
+        expr.cond,
+        null,
+        options
+      ) === true
+  );
 }

--- a/src/operators/expression/array/map.ts
+++ b/src/operators/expression/array/map.ts
@@ -16,21 +16,16 @@ export function $map(
   expr: { input: RawArray; as: string; in: AnyVal },
   options?: Options
 ): AnyVal {
-  const inputExpr = computeValue(obj, expr.input, null, options) as RawArray;
-  assert(
-    isArray(inputExpr),
-    `$map 'input' expression must resolve to an array`
+  const input = computeValue(obj, expr.input, null, options) as RawArray;
+  assert(isArray(input), `$map 'input' expression must resolve to an array`);
+
+  const tempKey = "$" + (expr.as || "this");
+  return input.map((o: AnyVal) =>
+    computeValue(
+      Object.assign({}, obj, { [tempKey]: o }),
+      expr.in,
+      null,
+      options
+    )
   );
-
-  const asExpr = expr.as || "this";
-  const inExpr = expr.in;
-
-  // HACK: add the "as" expression as a value on the object to take advantage of "resolve()"
-  // which will reduce to that value when invoked. The reference to the as expression will be prefixed with "$$".
-  // But since a "$" is stripped of before passing the name to "resolve()" we just need to prepend "$" to the key.
-  const tempKey = "$" + asExpr;
-  return inputExpr.map((v: AnyVal) => {
-    obj[tempKey] = v;
-    return computeValue(obj, inExpr, null, options);
-  });
 }

--- a/test/expression/array_operators.ts
+++ b/test/expression/array_operators.ts
@@ -357,6 +357,40 @@ test("Array Operators: $map using object context", (t) => {
   t.end();
 });
 
+test("Array Operators: $map using frozen objects", (t) => {
+  // $map
+  const result = aggregate(
+    [
+      Object.freeze({ _id: 1, quizzes: [5, 6, 7], adjustment: 2 }),
+      Object.freeze({ _id: 2, quizzes: [], adjustment: 2 }),
+      Object.freeze({ _id: 3, quizzes: [3, 8, 9], adjustment: 2 }),
+    ],
+    [
+      {
+        $project: {
+          adjustedGrades: {
+            $map: {
+              input: "$quizzes",
+              in: { $add: ["$$this", "$adjustment"] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, adjustedGrades: [7, 8, 9] },
+      { _id: 2, adjustedGrades: [] },
+      { _id: 3, adjustedGrades: [5, 10, 11] },
+    ],
+    result,
+    "can apply $map operator"
+  );
+  t.end();
+});
+
 test("Array Operators: $filter", (t) => {
   // $filter
   const result = aggregate(
@@ -433,6 +467,40 @@ test("Array Operators: $filter using object context", (t) => {
       { _id: 1, quizzes: [5, 6, 7], minimum: 5 },
       { _id: 2, quizzes: [], minimum: 5 },
       { _id: 3, quizzes: [3, 8, 9], minimum: 5 },
+    ],
+    [
+      {
+        $project: {
+          passingGrades: {
+            $filter: {
+              input: "$quizzes",
+              cond: { $gt: ["$$this", 5] },
+            },
+          },
+        },
+      },
+    ]
+  );
+
+  t.deepEqual(
+    [
+      { _id: 1, passingGrades: [6, 7] },
+      { _id: 2, passingGrades: [] },
+      { _id: 3, passingGrades: [8, 9] },
+    ],
+    result,
+    "can apply $filter operator"
+  );
+  t.end();
+});
+
+test("Array Operators: $filter using frozen objects", (t) => {
+  // $filter
+  const result = aggregate(
+    [
+      Object.freeze({ _id: 1, quizzes: [5, 6, 7], minimum: 5 }),
+      Object.freeze({ _id: 2, quizzes: [], minimum: 5 }),
+      Object.freeze({ _id: 3, quizzes: [3, 8, 9], minimum: 5 }),
     ],
     [
       {


### PR DESCRIPTION
Relating to #188, it seems that the $map and $filter operators were just mutating the input directly to inject the context, which was failing if a frozen object was passed.

This updates the logic in $map/$filter to create a new object on each iteration to inject the context, so that the original input doesn't need to be mutated.