### PR TITLE
fix: reset remainder after its been used and update date_range_lesser…

### DIFF
--- a/src/operators/expression/date/dateFromParts.ts
+++ b/src/operators/expression/date/dateFromParts.ts
@@ -32,7 +32,6 @@ export function $dateFromParts(
   options?: Options
 ): AnyVal {
   const args = computeValue(obj, expr, null, options) as DateArgs;
-
   const minuteOffset = parseTimezone(args.timezone);
 
   // assign default and adjust value ranges of the different parts
@@ -45,6 +44,9 @@ export function $dateFromParts(
 
     // add remainder from previous part. units should already be correct
     let part = ((args[k] as number) || 0) + remainder;
+
+    // reset remainder now that it's been used.
+    remainder = 0;
 
     // 1. compute the remainder for the next part
     // 2. adjust the current part to a valid range

--- a/test/operators/expression/date.test.ts
+++ b/test/operators/expression/date.test.ts
@@ -276,7 +276,7 @@ describe("Date Operators: $dateFromParts", () => {
           $dateFromParts: { year: 2017, month: 14, day: 1, hour: 12 },
         },
         date_range_lesser: {
-          $dateFromParts: { year: 2017, month: 0, day: 1, hour: 12 },
+          $dateFromParts: { year: 2017, month: 2, day: 0, hour: 12 },
         },
       },
     },
@@ -291,7 +291,7 @@ describe("Date Operators: $dateFromParts", () => {
   });
 
   it("can apply $dateFromParts with date parts below range of values", () => {
-    expect(result.date_range_lesser).toEqual(new Date("2016-12-01T12:00:00Z"));
+    expect(result.date_range_lesser).toEqual(new Date("2017-01-31T12:00:00Z"));
   });
 
   it("can apply $dateFromParts with timezone", () => {


### PR DESCRIPTION
… test

This fixes #222. The issue was that `remainder` was being carried over inside the for loop. Original test didn't catch it because the "below-min-val" was second last (month), so it would only update the year (as it should). 

If another date part earlier in the array (such as day) was below the minimum value, then remainder would mutate all subsequent parts in the date.