### PR TITLE
Added failing test cases for dateFromString

### DIFF
--- a/test/operators/expression/date.test.ts
+++ b/test/operators/expression/date.test.ts
@@ -114,6 +114,16 @@ support.runTest("operators/expression/date", {
     ],
 
     [
+      { dateString: "2017-02-08T12:10:40.787Z" },
+      new Date("2017-02-08T12:10:40.787Z"),
+    ],
+
+    [
+      { dateString: "2017-02-08T12:10:40Z" },
+      new Date("2017-02-08T12:10:40.000Z"),
+    ],
+
+    [
       { dateString: "2017-02-08T12:10:40.787", timezone: "-0500" },
       new Date("2017-02-08T17:10:40.787Z"),
     ],


### PR DESCRIPTION
refs #228

- These demonstrate the issue with dateFromString not working if there is a Z in dateString

---

I have done a bit of debugging and discovered that it's failing on the regex.exec clause here:

https://github.com/kofrasa/mingo/blob/667fc6124ff8709f575a1f9e9e03aa8fbabbd191/src/operators/expression/date/dateFromString.ts#L95

But I'm not entirely sure what that clause is meant to do so I'm a little unsure what a fix would look like.