### PR TITLE
feat: Allow multiple arguments to $ifNull conditional

### DIFF
--- a/src/operators/expression/conditional/ifNull.ts
+++ b/src/operators/expression/conditional/ifNull.ts
@@ -4,11 +4,10 @@
 
 import { computeValue, Options } from "../../../core";
 import { AnyVal, RawArray, RawObject } from "../../../types";
-import { assert, isArray, isNil } from "../../../util";
+import { isNil } from "../../../util";
 
 /**
- * Evaluates an expression and returns the first expression if it evaluates to a non-null value.
- * Otherwise, $ifNull returns the second expression's value.
+ * Evaluates an expression and returns the first non-null value.
  *
  * @param obj
  * @param expr
@@ -19,10 +18,6 @@ export function $ifNull(
   expr: RawArray,
   options?: Options
 ): AnyVal {
-  assert(
-    isArray(expr) && expr.length === 2,
-    "$ifNull expression must resolve to array(2)"
-  );
-  const args = computeValue(obj, expr, null, options);
-  return isNil(args[0]) ? args[1] : args[0];
+  const args = computeValue(obj, expr, null, options) as RawArray[];
+  return args.find((arg) => !isNil(arg));
 }

--- a/test/operators/expression/conditional.test.ts
+++ b/test/operators/expression/conditional.test.ts
@@ -43,6 +43,7 @@ support.runTest("operators/expression/conditional", {
     [[null, "Unspecified"], "Unspecified"],
     [[undefined, "Unspecified"], "Unspecified"],
     [[5, "Unspecified"], 5],
-    [[5, "Unspecified", "error"], "invalid arguments", { err: true }],
+    [[5, "Unspecified", "Dummy"], 5],
+    [[null, null, "Unspecified"], "Unspecified"],
   ],
 });


### PR DESCRIPTION
The latest versions of MongoDb allow multiple arguments to the `$ifNull` operator: https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#mongodb-expression-exp.-ifNull