### PR TITLE
ADD create package.json files for subpackages

### DIFF
--- a/build.js
+++ b/build.js
@@ -66,7 +66,7 @@ function createModule() {
         "es2015": path.relative(subPackagePath, path.join(OUT_DIR, esPath)),
         "jsnext:main": path.relative(subPackagePath, path.join(OUT_DIR, esPath)),
         "types": path.relative(subPackagePath, path.join(OUT_DIR, typesPath)),
-        "sideEffects": false
+        "sideEffects": key.startsWith("./init/")
       };
       fs.writeFileSync(
         path.join(subPackagePath, "package.json"),

--- a/build.js
+++ b/build.js
@@ -53,6 +53,27 @@ function createModule() {
     const esPath = `./es/${s.slice(2)}.js`;
     const key = s.endsWith("/index") ? s.slice(0, -6) : s;
     if (!key) return;
+
+    // create subpackage package.json
+    if (key !== ".") {
+      const subPackagePath = path.join(OUT_DIR, key);
+      if (!fs.existsSync(subPackagePath)) {
+        fs.mkdirSync(subPackagePath, { recursive: true });
+      }
+      const subPackageJson = {
+        "main": path.relative(subPackagePath, path.join(OUT_DIR, libPath)),
+        "module": path.relative(subPackagePath, path.join(OUT_DIR, esPath)),
+        "es2015": path.relative(subPackagePath, path.join(OUT_DIR, esPath)),
+        "jsnext:main": path.relative(subPackagePath, path.join(OUT_DIR, esPath)),
+        "types": path.relative(subPackagePath, path.join(OUT_DIR, typesPath)),
+        "sideEffects": false
+      };
+      fs.writeFileSync(
+        path.join(subPackagePath, "package.json"),
+        JSON.stringify(subPackageJson, null, 2)
+      );
+    }
+
     packageJson.exports[key] = {
       types: typesPath,
       node: libPath,


### PR DESCRIPTION
Related issue: https://github.com/kofrasa/mingo/issues/295#issuecomment-1373494118

This PR will create a `package.json` for each subpackage in the build output. This allows bundlers that do not understand the `exports` field in the root `package.json`, to still consume the library correctly, like the react-native metro bundler or the vscode typescript checker. Similar to how [rxjs](https://www.npmjs.com/package/rxjs?activeTab=explore) does it.
Also this sets `sideEffects: false` for all subpackages, because they do not rely on side effects anyways.

I tested this by coping over the build output into my projects node_modules and then running a build there.

@kofrasa 