### PR TITLE
Fix $size predicate failing when applied to undefined array

### DIFF
--- a/src/operators/_predicates.ts
+++ b/src/operators/_predicates.ts
@@ -298,7 +298,7 @@ export function $size(
   b: number,
   options?: PredicateOptions
 ): boolean {
-  return a.length === b;
+  return Array.isArray(a) && a.length === b;
 }
 
 function isNonBooleanOperator(name: string): boolean {


### PR DESCRIPTION
When testing a query containing `fieldName: {$size: 1}` on a JSON where `fieldName` is undefined, it fails because of undefined dereferencing of the array.