### PR TITLE
refactor: add operators with addOperators in context constructor

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -11,7 +11,6 @@ import {
 } from "./types";
 import {
   assert,
-  cloneDeep,
   has,
   isArray,
   isFunction,
@@ -20,7 +19,6 @@ import {
   isObjectLike,
   isOperator,
   isString,
-  merge,
   resolve
 } from "./util";
 
@@ -338,27 +336,23 @@ type PipelineOps = Record<string, PipelineOperator>;
 type WindowOps = Record<string, WindowOperator>;
 
 export class Context {
-  private readonly operators: ContextMap;
+  private readonly operators: ContextMap = {
+    [OperatorType.ACCUMULATOR]: {},
+    [OperatorType.EXPRESSION]: {},
+    [OperatorType.PIPELINE]: {},
+    [OperatorType.PROJECTION]: {},
+    [OperatorType.QUERY]: {},
+    [OperatorType.WINDOW]: {}
+  };
 
   private constructor(ops: ContextMap) {
-    this.operators = cloneDeep(ops) as typeof ops;
+    for (const [type, operators] of Object.entries(ops)) {
+      this.addOperators(type as OperatorType, operators as OperatorMap);
+    }
   }
 
   static init(ops: ContextMap = {}): Context {
-    return new Context(
-      merge(
-        {
-          [OperatorType.ACCUMULATOR]: {},
-          [OperatorType.EXPRESSION]: {},
-          [OperatorType.PIPELINE]: {},
-          [OperatorType.PROJECTION]: {},
-          [OperatorType.QUERY]: {},
-          [OperatorType.WINDOW]: {}
-        },
-        ops,
-        { skipValidation: true }
-      )
-    );
+    return new Context(ops);
   }
 
   static from(ctx: Context): Context {


### PR DESCRIPTION
~~Spreading the imports to objects converts them to plain objects again and resolves the issues discussed in #390~~
~~resolves #390~~

**Update**: see [this comment](https://github.com/kofrasa/mingo/pull/391#issuecomment-1770912159)