### PR TITLE
Fix ESM module resolution in Vitest due to `package.json` format

### DIFF
--- a/build.js
+++ b/build.js
@@ -90,6 +90,7 @@ function createModule() {
 
     packageJson.exports[key] = {
       types: typesPath,
+      import: esmPath,
       node: cjsPath,
       require: cjsPath,
       default: esmPath


### PR DESCRIPTION
This originally started as an investigation into an issue in RxDB which uses `mingo` as a dependency. My problem was essentially similar to https://github.com/pubkey/rxdb/issues/5452.

After some initial digging and futzing around, I discovered that this was due to how Vitest's module resolution works: https://github.com/vitest-dev/vitest/discussions/4233

Essentially, when building for the web, Vite will properly resolve the `ESM` import on the `exports.*.default` key. However, when running inside of Vitest, it uses the `exports.*.node` resolution because Vitest is targetting the node environment. By simply adding a `import` key to the built `package.json` file this fixes the issues within Vitest. Also worth noting, if the `import` key is _below_ the `node` key, Vitest still uses the `node` key resolution instead.