### PR TITLE
Fix: Add support for full/abbreviated months in $dateFromString

### DIFF
--- a/src/operators/expression/date/_internal.ts
+++ b/src/operators/expression/date/_internal.ts
@@ -115,21 +115,20 @@ export interface DatePartFormatter {
   padding: number;
   re: RegExp;
 }
-
-export const MONTHS = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-] as const;
+export const MONTHS: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12
+};
 
 /** Table of date format specifiers. Defined statically to support tree-shaking. */
 export const DATE_SYM_TABLE: Readonly<Record<string, DatePartFormatter>> = {

--- a/src/operators/expression/date/dateFromString.ts
+++ b/src/operators/expression/date/dateFromString.ts
@@ -8,6 +8,7 @@ import {
   DATE_FORMAT_SYM_RE,
   DATE_SYM_TABLE,
   MINUTES_PER_HOUR,
+  MONTHS,
   parseTimezone
 } from "./_internal";
 
@@ -18,7 +19,7 @@ function tzLetterOffset(c: string): number {
 }
 
 const regexStrip = (s: string): string =>
-  s.replace(/^\//, "").replace(/\/$/, "");
+  s.replace(/^\//, "").replace(/\/$/, "").replace(/\/i/, "");
 
 const REGEX_SPECIAL_CHARS = ["^", ".", "-", "*", "?", "$"] as const;
 function regexQuote(s: string): string {
@@ -63,6 +64,8 @@ export const $dateFromString: ExpressionOperator<Any> = (
   const dateParts: {
     year?: number;
     month?: number;
+    full_month?: string;
+    abbr_month?: string;
     day?: number;
     hour?: number;
     minute?: number;
@@ -97,6 +100,17 @@ export const $dateFromString: ExpressionOperator<Any> = (
       } else {
         dateParts[props.name] = null;
       }
+    }
+  }
+  // Transform month names to month number
+  if (isNil(dateParts.month)) {
+    const abbrMonth = (
+      dateParts.full_month?.slice(0, 3) ??
+      dateParts.abbr_month ??
+      ""
+    ).toLowerCase();
+    if (MONTHS[abbrMonth]) {
+      dateParts.month = MONTHS[abbrMonth];
     }
   }
 

--- a/test/operators/expression/date/dateFromString.test.ts
+++ b/test/operators/expression/date/dateFromString.test.ts
@@ -45,6 +45,20 @@ runTest(testPath(__filename), {
         timezone: "-0500"
       },
       new Date("2017-02-09T08:35:02.055Z")
+    ],
+    [
+      {
+        dateString: "10 June 2025",
+        format: "%d %B %Y"
+      },
+      new Date("2025-06-10T00:00:00Z")
+    ],
+    [
+      {
+        dateString: "18 Apr 2025",
+        format: "%d %b %Y"
+      },
+      new Date("2025-04-18T00:00:00Z")
     ]
   ]
 });


### PR DESCRIPTION
After a long time scratching my head why date parsing didn't work correctly using the `$dateFromString` operator, I discovered that `mingo` didn't have support (yet) for the `%b` and `%B` formatting options. 

Not sure if this is the best way to solve it, feel free to suggest a better approach. Thanks!