### PR TITLE
fix: respect configurable idKey in update operators

### DIFF
--- a/src/operators/update/_internal.ts
+++ b/src/operators/update/_internal.ts
@@ -109,6 +109,9 @@ export type Action<T = Any> = (
 const ERR_MISSING_FIELD =
   "You must include the array field for '.$' as part of the query document.";
 
+const ERR_IMMUTABLE_FIELD = (path: string, idKey: string) =>
+  `Performing an update on the path '${path}' would modify the immutable field '${idKey}'.`;
+
 /**
  * Walks the expression and apply the given action for each key-value pair.
  *
@@ -214,6 +217,13 @@ export function buildParams(
         // add query for matching condition.
         queries[field] = new Query({ [k]: condition[k] }, options);
       }
+
+      // assert id field is not being modified (MongoDB immutability constraint)
+      const idKey = options.idKey;
+      assert(
+        node.selector !== idKey && !node.selector.startsWith(`${idKey}.`),
+        ERR_IMMUTABLE_FIELD(node.selector, idKey)
+      );
 
       // assert there are no conflicting selectors
       assert(

--- a/src/operators/update/rename.ts
+++ b/src/operators/update/rename.ts
@@ -1,5 +1,5 @@
 import { AnyObject, ArrayOrObject, Options } from "../../types";
-import { has } from "../../util";
+import { assert, has } from "../../util";
 import {
   Action,
   applyUpdate,
@@ -8,6 +8,9 @@ import {
 } from "./_internal";
 import { $set } from "./set";
 
+const isIdPath = (path: string, idKey: string) =>
+  path === idKey || path.startsWith(`${idKey}.`);
+
 /** Replaces the value of a field with the specified value. */
 export const $rename = (
   obj: AnyObject,
@@ -15,6 +18,15 @@ export const $rename = (
   arrayFilters: AnyObject[] = [],
   options: Options = DEFAULT_OPTIONS
 ) => {
+  // validate target fields are not id field (source fields validated in walkExpression)
+  const idKey = options.idKey ?? "_id";
+  for (const target of Object.values(expr)) {
+    assert(
+      !isIdPath(target, idKey),
+      `Performing an update on the path '${target}' would modify the immutable field '${idKey}'.`
+    );
+  }
+
   const res: string[] = [];
   const changed = walkExpression(expr, arrayFilters, options, ((
     val,

--- a/test/updater.test.ts
+++ b/test/updater.test.ts
@@ -31,6 +31,64 @@ describe("updater", () => {
     });
   });
 
+  describe("_id Immutability", () => {
+    const ERR_MSG = /would modify the immutable field '_id'/;
+
+    it("should FAIL when $set targets _id field", () => {
+      const doc = { _id: "abc123", name: "John" };
+      expect(() => update(doc, { $set: { _id: "xyz789" } })).toThrow(ERR_MSG);
+    });
+
+    it("should FAIL when $set targets nested _id field", () => {
+      const doc = { _id: { a: 1, b: 2 }, name: "John" };
+      expect(() => update(doc, { $set: { "_id.a": 3 } })).toThrow(ERR_MSG);
+    });
+
+    it("should FAIL when $unset targets _id field", () => {
+      const doc = { _id: "abc123", name: "John" };
+      expect(() => update(doc, { $unset: { _id: "" } })).toThrow(ERR_MSG);
+    });
+
+    it("should FAIL when $rename source is _id field", () => {
+      const doc = { _id: "abc123", name: "John" };
+      expect(() => update(doc, { $rename: { _id: "oldId" } })).toThrow(ERR_MSG);
+    });
+
+    it("should FAIL when $rename target is _id field", () => {
+      const doc = { tempId: "abc123", name: "John" };
+      expect(() => update(doc, { $rename: { tempId: "_id" } })).toThrow(
+        ERR_MSG
+      );
+    });
+
+    it("should FAIL when $rename target is nested _id path", () => {
+      const doc = { tempId: "abc123", name: "John" };
+      expect(() => update(doc, { $rename: { tempId: "_id.value" } })).toThrow(
+        ERR_MSG
+      );
+    });
+
+    it("should FAIL when $inc targets _id field", () => {
+      const doc = { _id: 100, name: "John" };
+      expect(() => update(doc, { $inc: { _id: 1 } })).toThrow(ERR_MSG);
+    });
+
+    it("should allow updating fields that contain 'id' but not '_id'", () => {
+      const doc = { _id: "abc123", id: "old", myId: "test" };
+      update(doc, { $set: { id: "new", myId: "updated" } });
+      expect(doc.id).toBe("new");
+      expect(doc.myId).toBe("updated");
+      expect(doc._id).toBe("abc123");
+    });
+
+    it("should allow updating _id_backup field (not _id)", () => {
+      const doc = { _id: "abc123", _id_backup: "old" };
+      update(doc, { $set: { _id_backup: "new" } });
+      expect(doc._id_backup).toBe("new");
+      expect(doc._id).toBe("abc123");
+    });
+  });
+
   describe("update()", () => {
     const obj = {};
     beforeEach(() => {


### PR DESCRIPTION
## Summary

Adds immutability validation to update operators, respecting the configurable `idKey` option.

## Problem

MongoDB prohibits modifying the document identity field after creation. Per [MongoDB docs](https://www.mongodb.com/docs/manual/core/document/#field-names):

> "The field name _id is reserved for use as a primary key; its value must be unique in the collection, is immutable, and may be of any type other than an array or regex."

Mingo's update operators (`$set`, `$unset`, `$inc`, `$rename`, etc.) did not enforce this constraint.

## Solution

Update operators now validate that the identity field cannot be modified:

- Uses `options.idKey` (defaults to `"_id"`) for the immutability check
- Throws on attempts to modify `idKey` or `idKey.*` paths
- Error message matches MongoDB: `"Performing an update on the path '<path>' would modify the immutable field '<idKey>'."`

### Files Changed

- `src/operators/update/_internal.ts` - Add immutability check in `buildParams()` using `options.idKey`
- `src/operators/update/rename.ts` - Validate both source and target paths respect `idKey`
- `test/operators/update.test.ts` - Add comprehensive tests for all update operators

## Examples

```typescript
// Default idKey: "_id"
update({ _id: "123", name: "test" }, { $set: { _id: "456" } });
// Throws: "Performing an update on the path '_id' would modify the immutable field '_id'."

// Custom idKey: "id"  
update({ id: "123", name: "test" }, { $set: { id: "456" } }, [], { idKey: "id" });
// Throws: "Performing an update on the path 'id' would modify the immutable field 'id'."

// Nested paths also protected
update({ _id: { x: 1 } }, { $set: { "_id.x": 2 } });
// Throws: "Performing an update on the path '_id.x' would modify the immutable field '_id'."
```