### PR TITLE
fix($replaceAll/$replaceOne): treat find as literal string (correctness + ReDoS)

### DIFF
--- a/src/operators/expression/string/replaceAll.ts
+++ b/src/operators/expression/string/replaceAll.ts
@@ -28,5 +28,8 @@ export const $replaceAll = (
   if (!isString(replacement))
     return errExpectString(foe, `${OP} 'replacement'`);
 
-  return input.replace(new RegExp(find, "g"), replacement);
+  // MongoDB treats `find` and `replacement` as literal strings (no regex,
+  // no `$` substitution patterns). Using a literal split/join keeps parity and
+  // avoids ReDoS from a regex compiled out of a (possibly untrusted) `find`.
+  return input.split(find).join(replacement);
 };

--- a/src/operators/expression/string/replaceOne.ts
+++ b/src/operators/expression/string/replaceOne.ts
@@ -27,5 +27,10 @@ export const $replaceOne = (
   if (!isString(replacement))
     return errExpectString(foe, `${OP} 'replacement'`);
 
-  return args.input.replace(args.find, args.replacement);
+  // MongoDB replaces only the first instance and treats `find`/`replacement`
+  // as literal strings. `String.prototype.replace` with a string pattern would
+  // still interpret `$`-substitution patterns in `replacement`, so splice manually.
+  const idx = input.indexOf(find);
+  if (idx < 0) return input;
+  return input.slice(0, idx) + replacement + input.slice(idx + find.length);
 };

--- a/test/operators/expression/string.test.ts
+++ b/test/operators/expression/string.test.ts
@@ -1278,3 +1278,59 @@ support.runTestPipeline("$replaceAll: More examples", [
     ]
   }
 ]);
+
+// Regression: MongoDB treats $replaceAll/$replaceOne `find` as a LITERAL string,
+// not a regular expression. Previously `find` was compiled with
+// `new RegExp(find, "g")`, so regex metacharacters in `find` matched the wrong
+// text (silent wrong output) and a crafted `find` could trigger catastrophic
+// backtracking (ReDoS) when the query came from untrusted input.
+support.runTestPipeline("$replaceAll: find is literal, not a regex", [
+  {
+    message: "regex metacharacters in find match literally",
+    input: [
+      { _id: 1, v: "a.b.c" },
+      { _id: 2, v: "axbxc" },
+      { _id: 3, v: "(a)+[b]" }
+    ],
+    pipeline: [
+      {
+        $project: {
+          v: { $replaceAll: { input: "$v", find: ".", replacement: "X" } }
+        }
+      }
+    ],
+    // literal '.' replaces only the real dots in #1; #2 and #3 have none
+    expected: [
+      { _id: 1, v: "aXbXc" },
+      { _id: 2, v: "axbxc" },
+      { _id: 3, v: "(a)+[b]" }
+    ]
+  },
+  {
+    message: "literal grouping/quantifier metacharacters in find",
+    input: [{ _id: 1, v: "x(a)+[b]y" }],
+    pipeline: [
+      {
+        $project: {
+          v: { $replaceAll: { input: "$v", find: "(a)+[b]", replacement: "Z" } }
+        }
+      }
+    ],
+    expected: [{ _id: 1, v: "xZy" }]
+  }
+]);
+
+support.runTestPipeline("$replaceOne: find is literal, first match only", [
+  {
+    message: "regex metacharacter in find matches literally, first occurrence",
+    input: [{ _id: 1, v: "a.b.c" }],
+    pipeline: [
+      {
+        $project: {
+          v: { $replaceOne: { input: "$v", find: ".", replacement: "X" } }
+        }
+      }
+    ],
+    expected: [{ _id: 1, v: "aXb.c" }]
+  }
+]);


### PR DESCRIPTION
## Summary

MongoDB’s [`$replaceAll`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceAll/) and [`$replaceOne`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/) match `find` as a **literal string** and substitute `replacement` literally. mingo compiled `find` into a global `RegExp`:

```ts
// src/operators/expression/string/replaceAll.ts (before)
return input.replace(new RegExp(find, "g"), replacement);
```

Two problems:

### 1. Silent wrong output — `find` metacharacters interpreted as regex

```
$replaceAll input="axbxc" find="." replacement="-"  → mingo "-----"  | MongoDB "axbxc"
$replaceAll input="a.b.c" find="." replacement="X"  → mingo "XXXXX"  | MongoDB "aXbXc"
```

Any `find` containing `. * + ? ( ) [ ] { } | ^ $ \` silently matches the wrong text.

### 2. ReDoS when the query comes from untrusted input

```
$replaceAll find="(a+)+$" on a 29-char input → ~18.5s event-loop block locally
```

Apps that accept Mongo-style aggregations from clients are exposed.

## Fix

- `$replaceAll`: `input.split(find).join(replacement)` — literal, regex-free (0ms on the pattern above).
- `$replaceOne`: splice the first literal occurrence via `indexOf`, also avoiding JS `$`-substitution patterns (`$&`, `$1`, `` $` ``) when the replacement is supplied via `$literal`.

## Tests

Added regression tests for literal-metacharacter `find` on both operators. All existing string-operator tests pass: **149/149** (`vitest run test/operators/expression/string.test.ts`).

## Notes

I fix this class of silent JS-vs-source-DB divergence across query layers (PowerSync sync-rules, Rocicorp Zero, InstantDB, Dexie, RxDB, TanStack DB — summary: https://github.com/orgs/powersync-ja/discussions/668). Happy to split the commit or route the ReDoS half through a private advisory if you prefer; since `find`-as-regex is also a plain correctness bug, a normal PR seemed the right default.