### PR TITLE
fix($strLenCP/$substrCP): index by Unicode code points, not UTF-16 code units

### DIFF
--- a/src/operators/expression/string/strLenCP.ts
+++ b/src/operators/expression/string/strLenCP.ts
@@ -9,5 +9,8 @@ import { errExpectString } from "../_internal";
 export const $strLenCP = (obj: AnyObject, expr: Any, options: Options): Any => {
   const s = evalExpr(obj, expr, options) as string;
   if (!isString(s)) return errExpectString(options.failOnError, "$strLenCP");
-  return s.length;
+  // Count Unicode code points, not UTF-16 code units. `String.length` counts
+  // code units, so any non-BMP code point (emoji, CJK Ext B-G, U+10000+) is
+  // double-counted. MongoDB $strLenCP counts code points.
+  return [...s].length;
 };

--- a/src/operators/expression/string/substrCP.ts
+++ b/src/operators/expression/string/substrCP.ts
@@ -22,6 +22,10 @@ export const $substrCP = (obj: AnyObject, expr: Any, options: Options): Any => {
   // If the argument resolves to a value of null or refers to a field that is missing, return an empty string.
   if (nil) return "";
   if (index < 0) return "";
-  if (count < 0) return s.substring(index);
-  return s.substring(index, index + count);
+  // Index by Unicode code points, not UTF-16 code units. `String.substring`
+  // slices by code units and can split a surrogate pair, returning an invalid
+  // unpaired surrogate. MongoDB $substrCP operates on code points.
+  const codePoints = [...s];
+  if (count < 0) return codePoints.slice(index).join("");
+  return codePoints.slice(index, index + count).join("");
 };

--- a/test/operators/expression/string.test.ts
+++ b/test/operators/expression/string.test.ts
@@ -70,7 +70,11 @@ support.runTest("operators/expression/string", {
     ["cafétéria", 9],
     ["", 0],
     [{ $strLenCP: { $literal: "$€λG" } }, 4],
-    ["寿司", 2]
+    ["寿司", 2],
+    // Non-BMP code points must count as 1 each, not 2 (UTF-16 code units).
+    ["😀", 1],
+    ["a😀b", 3],
+    ["𐀀ab", 3]
   ],
 
   $strcasecmp: [
@@ -94,7 +98,12 @@ support.runTest("operators/expression/string", {
     [["cafétéria", 0, 5], "cafét"],
     [["cafétéria", 5, 4], "éria"],
     [["cafétéria", 7, 3], "ia"],
-    [["cafétéria", 3, 1], "é"]
+    [["cafétéria", 3, 1], "é"],
+    // Non-BMP code points must not be split into unpaired surrogates.
+    [["a😀b", 0, 2], "a😀"],
+    [["😀😀😀", 0, 2], "😀😀"],
+    [["a😀b", 1, 1], "😀"],
+    [["𐀀ab", 0, 1], "𐀀"]
   ],
 
   $substrBytes: [


### PR DESCRIPTION
## Summary

`$strLenCP` and `$substrCP` are documented to operate on **Unicode code points**, but both used JS `String.length` / `String.substring`, which count and slice **UTF-16 code units**. For any non-BMP code point (emoji, CJK Extension B–G, U+10000+) the result diverges from MongoDB:

```js
$strLenCP("😀")          // → 2   (MongoDB: 1)
$strLenCP("a😀b")        // → 4   (MongoDB: 3)
$substrCP("a😀b", 0, 2)  // → "a\ud83d"  ← invalid unpaired surrogate (MongoDB: "a😀")
$substrCP("a😀b", 1, 1)  // → "\ud83d"   ← invalid unpaired surrogate (MongoDB: "😀")
```

`$substrCP` can return a lone surrogate, which is invalid Unicode and breaks downstream re-encoding. `$substrBytes` next to these already handles UTF-8 boundaries carefully, so the CP variants appear to have been overlooked.

## Fix

Iterate by code points via the spread operator (`[...s]`):
- `$strLenCP`: `return [...s].length;`
- `$substrCP`: slice a `[...s]` code-point array instead of `s.substring(...)`.

## Tests

Added non-BMP regression cases (emoji + U+10000) to the existing `$strLenCP`/`$substrCP` tables. BMP cases unchanged. Full string-operator suite: **153/153** passing.

## Context

Same code-point-vs-code-unit class I fixed in PowerSync sync-rules (#664/#665). Separate from my open mingo PR #607 (different operators, no overlap).