### PR TITLE
fix: update with $rename always fails

### DIFF
--- a/src/updater.ts
+++ b/src/updater.ts
@@ -342,13 +342,18 @@ function updateDocuments<T extends AnyObject>(
 
   const arrayFilters = updateConfig?.arrayFilters ?? [];
 
+  const renameTargets = Object.values(modifier.$rename ?? {}).map(target => ({
+    [target as string]: true
+  }));
+
+  const updateExpressions = [
+    ...(Object.values(modifier) as AnyObject[]),
+    ...renameTargets
+  ];
+
   // build parameters and add to locals
   opts.update({
-    updateParams: buildParams(
-      Object.values(modifier) as AnyObject[],
-      arrayFilters,
-      opts
-    )
+    updateParams: buildParams(updateExpressions, arrayFilters, opts)
   });
 
   const matchedCount = foundDocs.length;

--- a/test/updater.test.ts
+++ b/test/updater.test.ts
@@ -533,6 +533,38 @@ describe("updater", () => {
       ]);
     });
 
+    it("should rename a field", () => {
+      const people = [{ _id: 1, oldName: "Alice" }];
+
+      expect(
+        updateOne(people, { _id: 1 }, { $rename: { oldName: "name" } })
+      ).toEqual({
+        matchedCount: 1,
+        modifiedCount: 1,
+        modifiedFields: ["name", "oldName"],
+        modifiedIndex: 0
+      });
+
+      expect(people).toEqual([{ _id: 1, name: "Alice" }]);
+    });
+
+    it("should reject conflicting update paths from rename targets", () => {
+      const people = [{ _id: 1, oldName: "Alice", name: "Existing" }];
+
+      expect(() =>
+        updateOne(
+          people,
+          { _id: 1 },
+          {
+            $rename: { oldName: "name" },
+            $set: { name: "Bob" }
+          }
+        )
+      ).toThrow("updating the path 'name' would create a conflict at 'name'");
+
+      expect(people).toEqual([{ _id: 1, oldName: "Alice", name: "Existing" }]);
+    });
+
     it("should update with sort with filter specified", () => {
       const people = [
         { name: "Alice", state: "active", rating: 5 },


### PR DESCRIPTION
Fixes `$rename` handling in update functions.

`$rename` touches both the source path and the destination path, but `updateParams` included only the source path. 

For an update like:
```ts
{ $rename: { oldName: "name" } }
```
`updateParams` includes `oldName`, but not `name`.

That caused two problems:

Conflicts involving $rename destination paths were not detected. This would not be detected as a conflict:
```ts
updateOne(people, { _id: 1 }, {
  $rename: { oldName: "name" },
  $set: { name: "Bob" }
})
```

But when running any update with `$rename`, it would fail with:
`Cannot destructure property 'node' of 'params[key]' as it is undefined.`

---

This adds $rename destination paths to the update paths passed into buildParams, so they participate in the same path parsing and conflict validation as other update paths.

Adds regression tests for:

- applying $rename through update functions
- rejecting conflicts between $rename destination paths and other update operators

