### PR TITLE
fix: `$min` fails for empty field

### DIFF
--- a/src/operators/update/min.ts
+++ b/src/operators/update/min.ts
@@ -1,5 +1,5 @@
 import { AnyObject } from "../../types";
-import { compare } from "../../util";
+import { compare, has } from "../../util";
 import { applyUpdate, DEFAULT_OPTIONS, walkExpression } from "./_internal";
 
 /** Updates the value of the field to a specified value if the specified value is less than the current value of the field. */
@@ -16,7 +16,7 @@ export function $min(
         node,
         queries,
         (o: AnyObject, k: string | number) => {
-          if (compare(o[k], val) < 1) return false;
+          if (has(o, String(k)) && compare(o[k], val) < 1) return false;
           o[k] = val;
           return true;
         },

--- a/test/operators/update/min.test.ts
+++ b/test/operators/update/min.test.ts
@@ -9,6 +9,12 @@ describe("operators/update/min", () => {
     expect(state).toEqual({ _id: 1, highScore: 800, lowScore: 150 });
   });
 
+  it("should set missing field to specified value", () => {
+    const state = { _id: 1, highScore: 800 };
+    expect($min({ lowScore: 200 })(state)).toEqual(["lowScore"]);
+    expect(state).toEqual({ _id: 1, highScore: 800, lowScore: 200 });
+  });
+
   it("should ignore greater value", () => {
     const state = { _id: 1, highScore: 800, lowScore: 200 };
     expect($min({ lowScore: 300 })(state)).toEqual([]);


### PR DESCRIPTION
Expected behaviour: (https://www.mongodb.com/docs/manual/reference/operator/update/min/)
"If the field does not exist, the $min operator sets the field to the specified value."

Actual behaviour:
For a top-level missing field - does nothing.
For a nested missing field with missing parent object - it adds the (empty) missing parent and reports no change. This suggests there may be similar issues elsewhere.

