### PR TITLE
fix 2 operator edge cases

### DIFF
--- a/src/operators/update/bit.ts
+++ b/src/operators/update/bit.ts
@@ -37,15 +37,16 @@ export function $bit(
           (o: AnyObject, k: string) => {
             let n = o[k] as number;
             const v = val[op[0]];
-            if (n !== undefined && !(isNumber(n) && isNumber(v))) return false;
+            const missing = n === undefined;
+            if (!missing && !(isNumber(n) && isNumber(v))) return false;
             n = n || 0;
             switch (op[0]) {
               case "and":
-                return (o[k] = n & v) !== n;
+                return (o[k] = n & v) !== n || missing;
               case "or":
-                return (o[k] = n | v) !== n;
+                return (o[k] = n | v) !== n || missing;
               case "xor":
-                return (o[k] = n ^ v) !== n;
+                return (o[k] = n ^ v) !== n || missing;
             }
           },
           { buildGraph: true }

--- a/src/operators/update/inc.ts
+++ b/src/operators/update/inc.ts
@@ -20,9 +20,10 @@ export function $inc(
           queries,
           (o: AnyObject, k: string) => {
             if (isNumber(o[k]) || o[k] === undefined) {
+              const previous = o[k] as number | undefined;
               o[k] ||= 0;
               (o[k] as number) += val;
-              return true;
+              return o[k] !== previous;
             }
             return false;
           },

--- a/test/operators/update/bit.test.ts
+++ b/test/operators/update/bit.test.ts
@@ -37,6 +37,24 @@ describe("operators/update/bit", () => {
     });
   });
 
+  it("should report missing field updates that resolve to zero", () => {
+    const state = { _id: 1 };
+
+    expect(
+      $bit({
+        "a.and": { and: 5 },
+        "b.or": { or: 0 },
+        "c.xor": { xor: 0 }
+      })(state)
+    ).toEqual(["a.and", "b.or", "c.xor"]);
+    expect(state).toEqual({
+      _id: 1,
+      a: { and: 0 },
+      b: { or: 0 },
+      c: { xor: 0 }
+    });
+  });
+
   it("should returns null if value is not a number.", () => {
     const state = { _id: 1 };
 

--- a/test/operators/update/inc.test.ts
+++ b/test/operators/update/inc.test.ts
@@ -11,6 +11,12 @@ describe(testPath(import.meta.url), () => {
     expect(state).toEqual({ _id: 1, n: "Bob" });
   });
 
+  it("should not report a change when incrementing by zero", () => {
+    const state = { _id: 1, n: 1 };
+    expect($inc({ n: 0 })(state)).toEqual([]);
+    expect(state).toEqual({ _id: 1, n: 1 });
+  });
+
   it("should set field to current date", () => {
     const state = {
       _id: 1,


### PR DESCRIPTION
## $bit

When `$bit` creates a missing field whose computed value is 0, it updates the document but returns no modified path.


## $inc

When `$inc` is applied to an existing numeric field with an increment of 0, it reports a change despite no change happening. Mongo does not do this.
