### PR TITLE
validate operator args at runtime

### DIFF
--- a/src/operators/update/addToSet.ts
+++ b/src/operators/update/addToSet.ts
@@ -1,5 +1,5 @@
 import { Any, AnyObject } from "../../types";
-import { has, isArray, isObject, unique } from "../../util";
+import { assert, has, isArray, isObject, unique } from "../../util";
 import {
   applyUpdate,
   clone,
@@ -13,6 +13,14 @@ export function $addToSet(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const valueSpec of Object.values(expr)) {
+    assert(
+      !(isObject(valueSpec) && has(valueSpec, "$each")) ||
+        isArray(valueSpec.$each),
+      `The argument to $each in $addToSet must be an array.`
+    );
+  }
+
   return (obj: AnyObject) => {
     return walkExpression(expr, arrayFilters, options, (val, node, queries) => {
       const args = { $each: [val] };

--- a/src/operators/update/currentDate.ts
+++ b/src/operators/update/currentDate.ts
@@ -1,4 +1,5 @@
 import { AnyObject } from "../../types";
+import { assert, isObject } from "../../util";
 import { applyUpdate, DEFAULT_OPTIONS, walkExpression } from "./_internal";
 
 type CurrentDateType = true | { $type: "date" | "timestamp" };
@@ -9,6 +10,15 @@ export function $currentDate(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const dateSpec of Object.values(expr)) {
+    assert(
+      dateSpec === true ||
+        (isObject(dateSpec) &&
+          (dateSpec.$type === "date" || dateSpec.$type === "timestamp")),
+      `Invalid type for $currentDate. Please use a boolean ('true') or a $type expression ({$type: 'timestamp/date'}).`
+    );
+  }
+
   return (obj: AnyObject) => {
     return walkExpression<CurrentDateType>(
       expr,

--- a/src/operators/update/inc.ts
+++ b/src/operators/update/inc.ts
@@ -1,5 +1,5 @@
 import { AnyObject } from "../../types";
-import { isNumber } from "../../util";
+import { assert, isNumber } from "../../util";
 import { applyUpdate, DEFAULT_OPTIONS, walkExpression } from "./_internal";
 
 /** Increments a field by a specified value. */
@@ -8,6 +8,10 @@ export function $inc(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const amount of Object.values(expr)) {
+    assert(isNumber(amount), `Cannot increment with non-numeric argument.`);
+  }
+
   return (obj: AnyObject) => {
     return walkExpression<number>(
       expr,

--- a/src/operators/update/mul.ts
+++ b/src/operators/update/mul.ts
@@ -1,5 +1,5 @@
 import { AnyObject } from "../../types";
-import { isNumber } from "../../util";
+import { assert, isNumber } from "../../util";
 import { applyUpdate, DEFAULT_OPTIONS, walkExpression } from "./_internal";
 
 /** Multiply the value of a field by a number. */
@@ -8,6 +8,10 @@ export function $mul(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const factor of Object.values(expr)) {
+    assert(isNumber(factor), `Cannot multiply with non-numeric argument.`);
+  }
+
   return (obj: AnyObject) => {
     return walkExpression<number>(
       expr,

--- a/src/operators/update/pop.ts
+++ b/src/operators/update/pop.ts
@@ -1,5 +1,5 @@
 import { Any, AnyObject, SortSpec } from "../../types";
-import { isArray } from "../../util";
+import { assert, isArray } from "../../util";
 import { applyUpdate, DEFAULT_OPTIONS, walkExpression } from "./_internal";
 
 /** Removes the first or last element of an array. */
@@ -8,6 +8,10 @@ export function $pop(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const position of Object.values(expr)) {
+    assert(position === 1 || position === -1, `$pop argument must be 1 or -1.`);
+  }
+
   return (obj: AnyObject) => {
     return walkExpression<1 | -1>(
       expr,

--- a/src/operators/update/pull.ts
+++ b/src/operators/update/pull.ts
@@ -9,14 +9,19 @@ export function $pull(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  const predicates = Object.values(expr).map(pullSpec => {
+    // wrap simple values or condition objects
+    const wrap = !isObject(pullSpec) || Object.keys(pullSpec).some(isOperator);
+    const query = new Query(wrap ? { k: pullSpec } : pullSpec, options);
+    return wrap
+      ? (v: Any) => query.test({ k: v })
+      : (v: Any) => query.test(v as AnyObject);
+  });
+
   return (obj: AnyObject) => {
-    return walkExpression(expr, arrayFilters, options, (val, node, queries) => {
-      // wrap simple values or condition objects
-      const wrap = !isObject(val) || Object.keys(val).some(isOperator);
-      const query = new Query(wrap ? { k: val } : val, options);
-      const pred = wrap
-        ? (v: Any) => query.test({ k: v })
-        : (v: Any) => query.test(v as AnyObject);
+    let index = 0;
+    return walkExpression(expr, arrayFilters, options, (_, node, queries) => {
+      const pred = predicates[index++];
       return applyUpdate(obj, node, queries, (o: AnyObject, k: string) => {
         const prev = o[k] as Any[];
         if (!isArray(prev) || !prev.length) return false;

--- a/src/operators/update/pullAll.ts
+++ b/src/operators/update/pullAll.ts
@@ -1,4 +1,5 @@
 import { Any, AnyObject } from "../../types";
+import { assert, isArray } from "../../util";
 import { DEFAULT_OPTIONS } from "./_internal";
 import { $pull } from "./pull";
 
@@ -10,6 +11,7 @@ export function $pullAll(
 ) {
   const pullExpr: Record<string, AnyObject> = {};
   for (const k of Object.keys(expr)) {
+    assert(isArray(expr[k]), `$pullAll requires an array argument.`);
     pullExpr[k] = { $in: expr[k] };
   }
   return $pull(pullExpr, arrayFilters, options);

--- a/src/operators/update/push.ts
+++ b/src/operators/update/push.ts
@@ -1,9 +1,11 @@
 import { Any, AnyObject, SortSpec } from "../../types";
 import {
+  assert,
   compare,
   has,
   isArray,
   isEqual,
+  isInteger,
   isNumber,
   isObject,
   resolve
@@ -23,6 +25,23 @@ export function $push(
   arrayFilters: AnyObject[] = [],
   options = DEFAULT_OPTIONS
 ) {
+  for (const pushSpec of Object.values(expr)) {
+    if (isObject(pushSpec) && MODIFIERS.some(m => has(pushSpec, m))) {
+      assert(
+        isArray(pushSpec.$each),
+        `The argument to $each in $push must be an array.`
+      );
+      assert(
+        pushSpec.$slice === undefined || isInteger(pushSpec.$slice),
+        `The value for $slice must be an integer value.`
+      );
+      assert(
+        pushSpec.$position === undefined || isInteger(pushSpec.$position),
+        `The value for $position must be an integer value.`
+      );
+    }
+  }
+
   return (obj: AnyObject) => {
     return walkExpression(expr, arrayFilters, options, (val, node, queries) => {
       const args: {

--- a/src/operators/update/rename.ts
+++ b/src/operators/update/rename.ts
@@ -15,6 +15,7 @@ export function $rename(
   // validate target fields are not id field (source fields validated in walkExpression)
   const idKey = options.idKey;
   for (const target of Object.values(expr)) {
+    assert(typeof target === "string", `$rename target must be a string.`);
     assert(
       !isIdPath(target, idKey),
       `Performing an update on the path '${target}' would modify the immutable field '${idKey}'.`

--- a/test/updater.test.ts
+++ b/test/updater.test.ts
@@ -262,6 +262,19 @@ describe("updater", () => {
       });
     });
 
+    it("should not partially mutate when $pull has an invalid condition", () => {
+      const state = { count: 1, results: [1, 3, 5, 7] };
+
+      expect(() =>
+        update(state, {
+          $inc: { count: 1 },
+          $pull: { results: { $invalid: 1 } }
+        })
+      ).toThrow();
+
+      expect(state).toEqual({ count: 1, results: [1, 3, 5, 7] });
+    });
+
     it("should update different nested path of parent selector with multiple modifiers", () => {
       const state = {
         items: ["ball", "bat", "gloves"]


### PR DESCRIPTION
Adds basic runtime argument type validation to: $inc, $mul, $pop, $rename, $currentDate, $push, $addToSet, $pullAll
